### PR TITLE
Prepare to publish 0.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.6
+
+* Require version 2.0.0 of the Dart SDK.
+
 ## 0.10.5
 
 * Add a `SingleMapping.files` field which provides access to `SourceFile`s
@@ -9,7 +13,6 @@
 ## 0.10.4
 * Implement `highlight` in `SourceMapFileSpan`.
 * Require version `^1.3.0` of `source_span`.
-* Require version 2.0.0 of the Dart SDK.
 
 ## 0.10.3
  * Add `addMapping` and `containsMapping` members to `MappingBundle`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_maps
-version: 0.10.5
+version: 0.10.6
 author: Dart Team <misc@dartlang.org>
 description: Library to programmatically manipulate source map files.
 homepage: http://github.com/dart-lang/source_maps


### PR DESCRIPTION
Because pull request #27 got merged after #28, the changelog entry was incorrect.

This prepares the package so we can publish a new version without ALL CAPS constants, addressing https://github.com/dart-lang/sdk/issues/32749