### PR TITLE
Enforce and fix package:pedantic lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:pedantic/analysis_options.yaml

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -34,9 +34,7 @@ class SourceMapBuilder {
   /// identifier whose value will be stored in the source map. [isIdenfier]
   /// takes precedence over [target]'s `isIdentifier` value.
   void addSpan(SourceSpan source, SourceSpan target, {bool isIdentifier}) {
-    if (isIdentifier == null) {
-      isIdentifier = source is SourceMapSpan ? source.isIdentifier : false;
-    }
+    isIdentifier ??= source is SourceMapSpan ? source.isIdentifier : false;
 
     var name = isIdentifier ? source.text : null;
     _entries.add(Entry(source.start, target.start, name));
@@ -50,7 +48,7 @@ class SourceMapBuilder {
 
   /// Encodes all mappings added to this builder as a json map.
   Map build(String fileUrl) {
-    return SingleMapping.fromEntries(this._entries, fileUrl).toJson();
+    return SingleMapping.fromEntries(_entries, fileUrl).toJson();
   }
 
   /// Encodes all mappings added to this builder as a json string.
@@ -75,8 +73,9 @@ class Entry implements Comparable<Entry> {
   /// location in the target file. We sort primarily by the target offset
   /// because source map files are encoded by printing each mapping in order as
   /// they appear in the target file.
+  @override
   int compareTo(Entry other) {
-    int res = target.compareTo(other.target);
+    var res = target.compareTo(other.target);
     if (res != 0) return res;
     res = source.sourceUrl
         .toString()

--- a/lib/printer.dart
+++ b/lib/printer.dart
@@ -41,7 +41,7 @@ class Printer {
   void add(String str, {projectMarks = false}) {
     var chars = str.runes.toList();
     var length = chars.length;
-    for (int i = 0; i < length; i++) {
+    for (var i = 0; i < length; i++) {
       var c = chars[i];
       if (c == _LF || (c == _CR && (i + 1 == length || chars[i + 1] != _LF))) {
         // Return not followed by line-feed is treated as a new line.
@@ -66,7 +66,9 @@ class Printer {
   /// Append a [total] number of spaces in the target file. Typically used for
   /// formatting indentation.
   void addSpaces(int total) {
-    for (int i = 0; i < total; i++) _buff.write(' ');
+    for (var i = 0; i < total; i++) {
+      _buff.write(' ');
+    }
     _column += total;
   }
 
@@ -76,8 +78,8 @@ class Printer {
   /// this also records the name of the identifier in the source map
   /// information.
   void mark(mark) {
-    var loc;
-    var identifier = null;
+    SourceLocation loc;
+    String identifier;
     if (mark is SourceLocation) {
       loc = mark;
     } else if (mark is SourceSpan) {
@@ -101,7 +103,7 @@ class NestedPrinter implements NestedItem {
   /// Items recoded by this printer, which can be [String] literals,
   /// [NestedItem]s, and source map information like [SourceLocation] and
   /// [SourceSpan].
-  List _items = [];
+  final _items = <dynamic>[];
 
   /// Internal buffer to merge consecutive strings added to this printer.
   StringBuffer _buff;
@@ -178,7 +180,7 @@ class NestedPrinter implements NestedItem {
 
   /// Appends a string merging it with any previous strings, if possible.
   void _appendString(String s) {
-    if (_buff == null) _buff = StringBuffer();
+    _buff ??= StringBuffer();
     _buff.write(s);
   }
 
@@ -191,11 +193,14 @@ class NestedPrinter implements NestedItem {
   }
 
   void _indent(int indent) {
-    for (int i = 0; i < indent; i++) _appendString('  ');
+    for (var i = 0; i < indent; i++) {
+      _appendString('  ');
+    }
   }
 
   /// Returns a string representation of all the contents appended to this
   /// printer, including source map location tokens.
+  @override
   String toString() {
     _flush();
     return (StringBuffer()..writeAll(_items)).toString();
@@ -218,9 +223,10 @@ class NestedPrinter implements NestedItem {
   }
 
   /// Implements the [NestedItem] interface.
+  @override
   void writeTo(Printer printer) {
     _flush();
-    bool propagate = false;
+    var propagate = false;
     for (var item in _items) {
       if (item is NestedItem) {
         item.writeTo(printer);

--- a/lib/refactor.dart
+++ b/lib/refactor.dart
@@ -24,7 +24,7 @@ class TextEditTransaction {
   /// Creates a new transaction.
   TextEditTransaction(this.original, this.file);
 
-  bool get hasEdits => _edits.length > 0;
+  bool get hasEdits => _edits.isNotEmpty;
 
   /// Edit the original text, replacing text on the range [begin] and [end]
   /// with the [replacement]. [replacement] can be either a string or a
@@ -46,14 +46,14 @@ class TextEditTransaction {
   /// made, the printer simply contains the original string.
   NestedPrinter commit() {
     var printer = NestedPrinter();
-    if (_edits.length == 0) {
+    if (_edits.isEmpty) {
       return printer..add(original, location: _loc(0), isOriginal: true);
     }
 
     // Sort edits by start location.
     _edits.sort();
 
-    int consumed = 0;
+    var consumed = 0;
     for (var edit in _edits) {
       if (consumed > edit.begin) {
         var sb = StringBuffer();
@@ -64,7 +64,9 @@ class TextEditTransaction {
           ..write(' but have consumed ')
           ..write(consumed)
           ..write(' input characters. List of edits:');
-        for (var e in _edits) sb..write('\n    ')..write(e);
+        for (var e in _edits) {
+          sb..write('\n    ')..write(e);
+        }
         throw UnsupportedError(sb.toString());
       }
 
@@ -95,10 +97,12 @@ class _TextEdit implements Comparable<_TextEdit> {
 
   int get length => end - begin;
 
+  @override
   String toString() => '(Edit @ $begin,$end: "$replace")';
 
+  @override
   int compareTo(_TextEdit other) {
-    int diff = begin - other.begin;
+    var diff = begin - other.begin;
     if (diff != 0) return diff;
     return end - other.end;
   }
@@ -107,8 +111,8 @@ class _TextEdit implements Comparable<_TextEdit> {
 /// Returns all whitespace characters at the start of [charOffset]'s line.
 String guessIndent(String code, int charOffset) {
   // Find the beginning of the line
-  int lineStart = 0;
-  for (int i = charOffset - 1; i >= 0; i--) {
+  var lineStart = 0;
+  for (var i = charOffset - 1; i >= 0; i--) {
     var c = code.codeUnitAt(i);
     if (c == _LF || c == _CR) {
       lineStart = i + 1;
@@ -117,8 +121,8 @@ String guessIndent(String code, int charOffset) {
   }
 
   // Grab all the whitespace
-  int whitespaceEnd = code.length;
-  for (int i = lineStart; i < code.length; i++) {
+  var whitespaceEnd = code.length;
+  for (var i = lineStart; i < code.length; i++) {
     var c = code.codeUnitAt(i);
     if (c != _SPACE && c != _TAB) {
       whitespaceEnd = i;

--- a/lib/source_maps.dart
+++ b/lib/source_maps.dart
@@ -37,8 +37,8 @@
 /// [pkg]: http://pub.dartlang.org/packages/source_maps
 library source_maps;
 
-export "builder.dart";
-export "parser.dart";
-export "printer.dart";
-export "refactor.dart";
+export 'builder.dart';
+export 'parser.dart';
+export 'printer.dart';
+export 'refactor.dart';
 export 'src/source_map_span.dart';

--- a/lib/src/source_map_span.dart
+++ b/lib/src/source_map_span.dart
@@ -38,24 +38,38 @@ class SourceMapSpan extends SourceSpanBase {
 /// A wrapper aruond a [FileSpan] that implements [SourceMapSpan].
 class SourceMapFileSpan implements SourceMapSpan, FileSpan {
   final FileSpan _inner;
+  @override
   final bool isIdentifier;
 
+  @override
   SourceFile get file => _inner.file;
+  @override
   FileLocation get start => _inner.start;
+  @override
   FileLocation get end => _inner.end;
+  @override
   String get text => _inner.text;
+  @override
   String get context => _inner.context;
+  @override
   Uri get sourceUrl => _inner.sourceUrl;
+  @override
   int get length => _inner.length;
 
   SourceMapFileSpan(this._inner, {this.isIdentifier = false});
 
+  @override
   int compareTo(SourceSpan other) => _inner.compareTo(other);
+  @override
   String highlight({color}) => _inner.highlight(color: color);
+  @override
   SourceSpan union(SourceSpan other) => _inner.union(other);
+  @override
   FileSpan expand(FileSpan other) => _inner.expand(other);
+  @override
   String message(String message, {color}) =>
       _inner.message(message, color: color);
+  @override
   String toString() =>
-      _inner.toString().replaceAll("FileSpan", "SourceMapFileSpan");
+      _inner.toString().replaceAll('FileSpan', 'SourceMapFileSpan');
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -10,13 +10,13 @@ library source_maps.utils;
 /// and all items after `n` match too. The result is -1 when there are no
 /// items, 0 when all items match, and list.length when none does.
 // TODO(sigmund): remove this function after dartbug.com/5624 is fixed.
-int binarySearch(List list, bool matches(item)) {
-  if (list.length == 0) return -1;
+int binarySearch(List list, bool Function(dynamic) matches) {
+  if (list.isEmpty) return -1;
   if (matches(list.first)) return 0;
   if (!matches(list.last)) return list.length;
 
-  int min = 0;
-  int max = list.length - 1;
+  var min = 0;
+  var max = list.length - 1;
   while (min < max) {
     var half = min + ((max - min) ~/ 2);
     if (matches(list[half])) {

--- a/lib/src/vlq.dart
+++ b/lib/src/vlq.dart
@@ -28,7 +28,7 @@ const String BASE64_DIGITS =
 
 final Map<String, int> _digits = () {
   var map = <String, int>{};
-  for (int i = 0; i < 64; i++) {
+  for (var i = 0; i < 64; i++) {
     map[BASE64_DIGITS[i]] = i;
   }
   return map;
@@ -43,14 +43,14 @@ Iterable<String> encodeVlq(int value) {
     throw ArgumentError('expected 32 bit int, got: $value');
   }
   var res = <String>[];
-  int signBit = 0;
+  var signBit = 0;
   if (value < 0) {
     signBit = 1;
     value = -value;
   }
   value = (value << 1) | signBit;
   do {
-    int digit = value & VLQ_BASE_MASK;
+    var digit = value & VLQ_BASE_MASK;
     value >>= VLQ_BASE_SHIFT;
     if (value > 0) {
       digit |= VLQ_CONTINUATION_BIT;
@@ -65,9 +65,9 @@ Iterable<String> encodeVlq(int value) {
 /// iterator is advanced until a stop character is found (a character without
 /// the [VLQ_CONTINUATION_BIT]).
 int decodeVlq(Iterator<String> chars) {
-  int result = 0;
-  bool stop = false;
-  int shift = 0;
+  var result = 0;
+  var stop = false;
+  var shift = 0;
   while (!stop) {
     if (!chars.moveNext()) throw StateError('incomplete VLQ value');
     var char = chars.current;
@@ -89,7 +89,7 @@ int decodeVlq(Iterator<String> chars) {
   //   5 (101 binary) becomes -2
   //   6 (110 binary) becomes 3
   //   7 (111 binary) becomes -3
-  bool negate = (result & 1) == 1;
+  var negate = (result & 1) == 1;
   result = result >> 1;
   result = negate ? -result : result;
 

--- a/test/builder_test.dart
+++ b/test/builder_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 import 'package:source_maps/source_maps.dart';
 import 'common.dart';
 
-main() {
+void main() {
   test('builder - with span', () {
     var map = (SourceMapBuilder()
           ..addSpan(inputVar1, outputVar1)

--- a/test/common.dart
+++ b/test/common.dart
@@ -71,7 +71,7 @@ const Map<String, dynamic> EXPECTED_MAP = {
   'file': 'output.dart'
 };
 
-check(SourceSpan outputSpan, Mapping mapping, SourceMapSpan inputSpan,
+void check(SourceSpan outputSpan, Mapping mapping, SourceMapSpan inputSpan,
     bool realOffsets) {
   var line = outputSpan.start.line;
   var column = outputSpan.start.column;

--- a/test/end2end_test.dart
+++ b/test/end2end_test.dart
@@ -9,7 +9,7 @@ import 'package:source_maps/source_maps.dart';
 import 'package:source_span/source_span.dart';
 import 'common.dart';
 
-main() {
+void main() {
   test('end-to-end setup', () {
     expect(inputVar1.text, 'longVar1');
     expect(inputFunction.text, 'longName');
@@ -132,7 +132,7 @@ main() {
     expect(printer.text, out);
 
     var mapping = parse(printer.map);
-    checkHelper(SourceMapSpan inputSpan, int adjustment) {
+    void checkHelper(SourceMapSpan inputSpan, int adjustment) {
       var start = inputSpan.start.offset - adjustment;
       var end = (inputSpan.end.offset - adjustment) - 2;
       var span = SourceMapFileSpan(file.span(start, end),

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -70,7 +70,7 @@ const List SOURCE_MAP_BUNDLE = [
   MAP_WITH_SOURCE_LOCATION_AND_NAME_3,
 ];
 
-main() {
+void main() {
   test('parse', () {
     var mapping = parseJson(EXPECTED_MAP);
     check(outputVar1, mapping, inputVar1, false);
@@ -99,7 +99,7 @@ main() {
     SingleMapping map = parse(jsonEncode(MAP_WITH_NO_SOURCE_LOCATION));
     expect(map.lines.length, 1);
     expect(map.lines.first.entries.length, 1);
-    TargetEntry entry = map.lines.first.entries.first;
+    var entry = map.lines.first.entries.first;
 
     expect(entry.column, 0);
     expect(entry.sourceUrlId, null);
@@ -112,7 +112,7 @@ main() {
     SingleMapping map = parse(jsonEncode(MAP_WITH_SOURCE_LOCATION));
     expect(map.lines.length, 1);
     expect(map.lines.first.entries.length, 1);
-    TargetEntry entry = map.lines.first.entries.first;
+    var entry = map.lines.first.entries.first;
 
     expect(entry.column, 0);
     expect(entry.sourceUrlId, 0);
@@ -125,7 +125,7 @@ main() {
     SingleMapping map = parse(jsonEncode(MAP_WITH_SOURCE_LOCATION_AND_NAME));
     expect(map.lines.length, 1);
     expect(map.lines.first.entries.length, 1);
-    TargetEntry entry = map.lines.first.entries.first;
+    var entry = map.lines.first.entries.first;
 
     expect(entry.sourceUrlId, 0);
     expect(entry.sourceUrlId, 0);
@@ -138,18 +138,18 @@ main() {
     var inputMap = Map.from(MAP_WITH_SOURCE_LOCATION);
     inputMap['sourceRoot'] = '/pkg/';
     var mapping = parseJson(inputMap) as SingleMapping;
-    expect(mapping.spanFor(0, 0).sourceUrl, Uri.parse("/pkg/input.dart"));
+    expect(mapping.spanFor(0, 0).sourceUrl, Uri.parse('/pkg/input.dart'));
     expect(
         mapping
             .spanForLocation(
-                SourceLocation(0, sourceUrl: Uri.parse("ignored.dart")))
+                SourceLocation(0, sourceUrl: Uri.parse('ignored.dart')))
             .sourceUrl,
-        Uri.parse("/pkg/input.dart"));
+        Uri.parse('/pkg/input.dart'));
 
     var newSourceRoot = '/new/';
 
     mapping.sourceRoot = newSourceRoot;
-    inputMap["sourceRoot"] = newSourceRoot;
+    inputMap['sourceRoot'] = newSourceRoot;
 
     expect(mapping.toJson(), equals(inputMap));
   });
@@ -157,14 +157,14 @@ main() {
   test('parse with map URL', () {
     var inputMap = Map.from(MAP_WITH_SOURCE_LOCATION);
     inputMap['sourceRoot'] = 'pkg/';
-    var mapping = parseJson(inputMap, mapUrl: "file:///path/to/map");
+    var mapping = parseJson(inputMap, mapUrl: 'file:///path/to/map');
     expect(mapping.spanFor(0, 0).sourceUrl,
-        Uri.parse("file:///path/to/pkg/input.dart"));
+        Uri.parse('file:///path/to/pkg/input.dart'));
   });
 
   group('parse with bundle', () {
     var mapping =
-        parseJsonExtended(SOURCE_MAP_BUNDLE, mapUrl: "file:///path/to/map");
+        parseJsonExtended(SOURCE_MAP_BUNDLE, mapUrl: 'file:///path/to/map');
 
     test('simple', () {
       expect(
@@ -172,29 +172,29 @@ main() {
               .spanForLocation(SourceLocation(0,
                   sourceUrl: Uri.file('/path/to/output.dart')))
               .sourceUrl,
-          Uri.parse("file:///path/to/pkg/input1.dart"));
+          Uri.parse('file:///path/to/pkg/input1.dart'));
       expect(
           mapping
               .spanForLocation(SourceLocation(0,
                   sourceUrl: Uri.file('/path/to/output2.dart')))
               .sourceUrl,
-          Uri.parse("file:///path/to/pkg/input2.dart"));
+          Uri.parse('file:///path/to/pkg/input2.dart'));
       expect(
           mapping
               .spanForLocation(SourceLocation(0,
                   sourceUrl: Uri.file('/path/to/3/output.dart')))
               .sourceUrl,
-          Uri.parse("file:///path/to/pkg/input3.dart"));
+          Uri.parse('file:///path/to/pkg/input3.dart'));
 
       expect(
-          mapping.spanFor(0, 0, uri: "file:///path/to/output.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input1.dart"));
+          mapping.spanFor(0, 0, uri: 'file:///path/to/output.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input1.dart'));
       expect(
-          mapping.spanFor(0, 0, uri: "file:///path/to/output2.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input2.dart"));
+          mapping.spanFor(0, 0, uri: 'file:///path/to/output2.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input2.dart'));
       expect(
-          mapping.spanFor(0, 0, uri: "file:///path/to/3/output.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input3.dart"));
+          mapping.spanFor(0, 0, uri: 'file:///path/to/3/output.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input3.dart'));
     });
 
     test('package uris', () {
@@ -203,36 +203,36 @@ main() {
               .spanForLocation(SourceLocation(0,
                   sourceUrl: Uri.parse('package:1/output.dart')))
               .sourceUrl,
-          Uri.parse("file:///path/to/pkg/input1.dart"));
+          Uri.parse('file:///path/to/pkg/input1.dart'));
       expect(
           mapping
               .spanForLocation(SourceLocation(0,
                   sourceUrl: Uri.parse('package:2/output2.dart')))
               .sourceUrl,
-          Uri.parse("file:///path/to/pkg/input2.dart"));
+          Uri.parse('file:///path/to/pkg/input2.dart'));
       expect(
           mapping
               .spanForLocation(SourceLocation(0,
                   sourceUrl: Uri.parse('package:3/output.dart')))
               .sourceUrl,
-          Uri.parse("file:///path/to/pkg/input3.dart"));
+          Uri.parse('file:///path/to/pkg/input3.dart'));
 
-      expect(mapping.spanFor(0, 0, uri: "package:1/output.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input1.dart"));
-      expect(mapping.spanFor(0, 0, uri: "package:2/output2.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input2.dart"));
-      expect(mapping.spanFor(0, 0, uri: "package:3/output.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input3.dart"));
+      expect(mapping.spanFor(0, 0, uri: 'package:1/output.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input1.dart'));
+      expect(mapping.spanFor(0, 0, uri: 'package:2/output2.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input2.dart'));
+      expect(mapping.spanFor(0, 0, uri: 'package:3/output.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input3.dart'));
     });
 
     test('unmapped path', () {
-      var span = mapping.spanFor(0, 0, uri: "unmapped_output.dart");
-      expect(span.sourceUrl, Uri.parse("unmapped_output.dart"));
+      var span = mapping.spanFor(0, 0, uri: 'unmapped_output.dart');
+      expect(span.sourceUrl, Uri.parse('unmapped_output.dart'));
       expect(span.start.line, equals(0));
       expect(span.start.column, equals(0));
 
-      span = mapping.spanFor(10, 5, uri: "unmapped_output.dart");
-      expect(span.sourceUrl, Uri.parse("unmapped_output.dart"));
+      span = mapping.spanFor(10, 5, uri: 'unmapped_output.dart');
+      expect(span.sourceUrl, Uri.parse('unmapped_output.dart'));
       expect(span.start.line, equals(10));
       expect(span.start.column, equals(5));
     });
@@ -242,47 +242,47 @@ main() {
     });
 
     test('incomplete paths', () {
-      expect(mapping.spanFor(0, 0, uri: "output.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input1.dart"));
-      expect(mapping.spanFor(0, 0, uri: "output2.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input2.dart"));
-      expect(mapping.spanFor(0, 0, uri: "3/output.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input3.dart"));
+      expect(mapping.spanFor(0, 0, uri: 'output.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input1.dart'));
+      expect(mapping.spanFor(0, 0, uri: 'output2.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input2.dart'));
+      expect(mapping.spanFor(0, 0, uri: '3/output.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input3.dart'));
     });
 
     test('parseExtended', () {
       var mapping = parseExtended(jsonEncode(SOURCE_MAP_BUNDLE),
-          mapUrl: "file:///path/to/map");
+          mapUrl: 'file:///path/to/map');
 
-      expect(mapping.spanFor(0, 0, uri: "output.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input1.dart"));
-      expect(mapping.spanFor(0, 0, uri: "output2.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input2.dart"));
-      expect(mapping.spanFor(0, 0, uri: "3/output.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input3.dart"));
+      expect(mapping.spanFor(0, 0, uri: 'output.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input1.dart'));
+      expect(mapping.spanFor(0, 0, uri: 'output2.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input2.dart'));
+      expect(mapping.spanFor(0, 0, uri: '3/output.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input3.dart'));
     });
 
     test('build bundle incrementally', () {
       var mapping = MappingBundle();
 
       mapping.addMapping(parseJson(MAP_WITH_SOURCE_LOCATION_AND_NAME_1,
-          mapUrl: "file:///path/to/map"));
-      expect(mapping.spanFor(0, 0, uri: "output.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input1.dart"));
+          mapUrl: 'file:///path/to/map'));
+      expect(mapping.spanFor(0, 0, uri: 'output.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input1.dart'));
 
-      expect(mapping.containsMapping("output2.dart"), isFalse);
+      expect(mapping.containsMapping('output2.dart'), isFalse);
       mapping.addMapping(parseJson(MAP_WITH_SOURCE_LOCATION_AND_NAME_2,
-          mapUrl: "file:///path/to/map"));
-      expect(mapping.containsMapping("output2.dart"), isTrue);
-      expect(mapping.spanFor(0, 0, uri: "output2.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input2.dart"));
+          mapUrl: 'file:///path/to/map'));
+      expect(mapping.containsMapping('output2.dart'), isTrue);
+      expect(mapping.spanFor(0, 0, uri: 'output2.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input2.dart'));
 
-      expect(mapping.containsMapping("3/output.dart"), isFalse);
+      expect(mapping.containsMapping('3/output.dart'), isFalse);
       mapping.addMapping(parseJson(MAP_WITH_SOURCE_LOCATION_AND_NAME_3,
-          mapUrl: "file:///path/to/map"));
-      expect(mapping.containsMapping("3/output.dart"), isTrue);
-      expect(mapping.spanFor(0, 0, uri: "3/output.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input3.dart"));
+          mapUrl: 'file:///path/to/map'));
+      expect(mapping.containsMapping('3/output.dart'), isTrue);
+      expect(mapping.spanFor(0, 0, uri: '3/output.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input3.dart'));
     });
 
     // Test that the source map can handle cases where the uri passed in is
@@ -294,31 +294,31 @@ main() {
               .spanForLocation(SourceLocation(0,
                   sourceUrl: Uri.parse('http://localhost/output.dart')))
               .sourceUrl,
-          Uri.parse("file:///path/to/pkg/input1.dart"));
+          Uri.parse('file:///path/to/pkg/input1.dart'));
       expect(
           mapping
               .spanForLocation(SourceLocation(0,
                   sourceUrl: Uri.parse('http://localhost/output2.dart')))
               .sourceUrl,
-          Uri.parse("file:///path/to/pkg/input2.dart"));
+          Uri.parse('file:///path/to/pkg/input2.dart'));
       expect(
           mapping
               .spanForLocation(SourceLocation(0,
                   sourceUrl: Uri.parse('http://localhost/3/output.dart')))
               .sourceUrl,
-          Uri.parse("file:///path/to/pkg/input3.dart"));
+          Uri.parse('file:///path/to/pkg/input3.dart'));
 
       expect(
-          mapping.spanFor(0, 0, uri: "http://localhost/output.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input1.dart"));
+          mapping.spanFor(0, 0, uri: 'http://localhost/output.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input1.dart'));
       expect(
-          mapping.spanFor(0, 0, uri: "http://localhost/output2.dart").sourceUrl,
-          Uri.parse("file:///path/to/pkg/input2.dart"));
+          mapping.spanFor(0, 0, uri: 'http://localhost/output2.dart').sourceUrl,
+          Uri.parse('file:///path/to/pkg/input2.dart'));
       expect(
           mapping
-              .spanFor(0, 0, uri: "http://localhost/3/output.dart")
+              .spanFor(0, 0, uri: 'http://localhost/3/output.dart')
               .sourceUrl,
-          Uri.parse("file:///path/to/pkg/input3.dart"));
+          Uri.parse('file:///path/to/pkg/input3.dart'));
     });
   });
 
@@ -344,17 +344,17 @@ main() {
 
   test('parse extensions', () {
     var map = Map.from(EXPECTED_MAP);
-    map["x_foo"] = "a";
-    map["x_bar"] = [3];
+    map['x_foo'] = 'a';
+    map['x_bar'] = [3];
     SingleMapping mapping = parseJson(map);
     expect(mapping.toJson(), equals(map));
-    expect(mapping.extensions["x_foo"], equals("a"));
-    expect(mapping.extensions["x_bar"].first, equals(3));
+    expect(mapping.extensions['x_foo'], equals('a'));
+    expect(mapping.extensions['x_bar'].first, equals(3));
   });
 
-  group("source files", () {
-    group("from fromEntries()", () {
-      test("are null for non-FileLocations", () {
+  group('source files', () {
+    group('from fromEntries()', () {
+      test('are null for non-FileLocations', () {
         var mapping = SingleMapping.fromEntries([
           Entry(SourceLocation(10, line: 1, column: 8), outputVar1.start, null)
         ]);
@@ -368,36 +368,36 @@ main() {
       });
     });
 
-    group("from parse()", () {
-      group("are null", () {
-        test("with no sourcesContent field", () {
+    group('from parse()', () {
+      group('are null', () {
+        test('with no sourcesContent field', () {
           var mapping = parseJson(EXPECTED_MAP) as SingleMapping;
           expect(mapping.files, equals([null]));
         });
 
-        test("with null sourcesContent values", () {
+        test('with null sourcesContent values', () {
           var map = Map.from(EXPECTED_MAP);
-          map["sourcesContent"] = [null];
+          map['sourcesContent'] = [null];
           var mapping = parseJson(map) as SingleMapping;
           expect(mapping.files, equals([null]));
         });
 
-        test("with a too-short sourcesContent", () {
+        test('with a too-short sourcesContent', () {
           var map = Map.from(EXPECTED_MAP);
-          map["sourcesContent"] = [];
+          map['sourcesContent'] = [];
           var mapping = parseJson(map) as SingleMapping;
           expect(mapping.files, equals([null]));
         });
       });
 
-      test("are parsed from sourcesContent", () {
+      test('are parsed from sourcesContent', () {
         var map = Map.from(EXPECTED_MAP);
-        map["sourcesContent"] = ["hello, world!"];
+        map['sourcesContent'] = ['hello, world!'];
         var mapping = parseJson(map) as SingleMapping;
 
         var file = mapping.files[0];
-        expect(file.url, equals(Uri.parse("input.dart")));
-        expect(file.getText(0), equals("hello, world!"));
+        expect(file.url, equals(Uri.parse('input.dart')));
+        expect(file.getText(0), equals('hello, world!'));
       });
     });
   });

--- a/test/printer_test.dart
+++ b/test/printer_test.dart
@@ -10,7 +10,7 @@ import 'package:source_maps/source_maps.dart';
 import 'package:source_span/source_span.dart';
 import 'common.dart';
 
-main() {
+void main() {
   test('printer', () {
     var printer = Printer('output.dart');
     printer
@@ -55,7 +55,7 @@ main() {
     // 8 new lines in the source map:
     expect(printer.map.split(';').length, 8);
 
-    asFixed(SourceMapSpan s) =>
+    SourceMapSpan asFixed(SourceMapSpan s) =>
         SourceMapSpan(s.start, s.end, s.text, isIdentifier: s.isIdentifier);
 
     // The result is the same if we use fixed positions
@@ -114,7 +114,7 @@ main() {
       var lines = INPUT.trim().split('\n');
       expect(lines.length, 7);
       var printer = NestedPrinter();
-      for (int i = 0; i < lines.length; i++) {
+      for (var i = 0; i < lines.length; i++) {
         if (i == 5) printer.indent++;
         printer.addLine(lines[i].replaceAll('long', '_s').trim());
         if (i == 5) printer.indent--;

--- a/test/refactor_test.dart
+++ b/test/refactor_test.dart
@@ -10,13 +10,13 @@ import 'package:source_maps/parser.dart' show parse, Mapping;
 import 'package:source_span/source_span.dart';
 import 'package:term_glyph/term_glyph.dart' as term_glyph;
 
-main() {
+void main() {
   setUpAll(() {
     term_glyph.ascii = true;
   });
 
   group('conflict detection', () {
-    var original = "0123456789abcdefghij";
+    var original = '0123456789abcdefghij';
     var file = SourceFile.fromString(original);
 
     test('no conflict, in order', () {
@@ -25,7 +25,7 @@ main() {
       txn.edit(5, 5, '|');
       txn.edit(6, 6, '-');
       txn.edit(6, 7, '_');
-      expect((txn.commit()..build('')).text, "01.4|5-_789abcdefghij");
+      expect((txn.commit()..build('')).text, '01.4|5-_789abcdefghij');
     });
 
     test('no conflict, out of order', () {
@@ -37,7 +37,7 @@ main() {
       // that don't remove any of the original code.
       txn.edit(6, 7, '_');
       txn.edit(6, 6, '-');
-      expect((txn.commit()..build('')).text, "01.4|5-_789abcdefghij");
+      expect((txn.commit()..build('')).text, '01.4|5-_789abcdefghij');
     });
 
     test('conflict', () {
@@ -53,7 +53,7 @@ main() {
 
   test('generated source maps', () {
     var original =
-        "0123456789\n0*23456789\n01*3456789\nabcdefghij\nabcd*fghij\n";
+        '0123456789\n0*23456789\n01*3456789\nabcdefghij\nabcd*fghij\n';
     var file = SourceFile.fromString(original);
     var txn = TextEditTransaction(original, file);
     txn.edit(27, 29, '__\n    ');
@@ -62,70 +62,70 @@ main() {
     var output = printer.text;
     var map = parse(printer.map);
     expect(output,
-        "0123456789\n0*23456789\n01*34__\n    789\na___cdefghij\nabcd*fghij\n");
+        '0123456789\n0*23456789\n01*34__\n    789\na___cdefghij\nabcd*fghij\n');
 
     // Line 1 and 2 are unmodified: mapping any column returns the beginning
     // of the corresponding line:
     expect(
         _span(1, 1, map, file),
-        "line 1, column 1: \n"
-        "  ,\n"
-        "1 | 0123456789\n"
-        "  | ^\n"
+        'line 1, column 1: \n'
+        '  ,\n'
+        '1 | 0123456789\n'
+        '  | ^\n'
         "  '");
     expect(
         _span(1, 5, map, file),
-        "line 1, column 1: \n"
-        "  ,\n"
-        "1 | 0123456789\n"
-        "  | ^\n"
+        'line 1, column 1: \n'
+        '  ,\n'
+        '1 | 0123456789\n'
+        '  | ^\n'
         "  '");
     expect(
         _span(2, 1, map, file),
-        "line 2, column 1: \n"
-        "  ,\n"
-        "2 | 0*23456789\n"
-        "  | ^\n"
+        'line 2, column 1: \n'
+        '  ,\n'
+        '2 | 0*23456789\n'
+        '  | ^\n'
         "  '");
     expect(
         _span(2, 8, map, file),
-        "line 2, column 1: \n"
-        "  ,\n"
-        "2 | 0*23456789\n"
-        "  | ^\n"
+        'line 2, column 1: \n'
+        '  ,\n'
+        '2 | 0*23456789\n'
+        '  | ^\n'
         "  '");
 
     // Line 3 is modified part way: mappings before the edits have the right
     // mapping, after the edits the mapping is null.
     expect(
         _span(3, 1, map, file),
-        "line 3, column 1: \n"
-        "  ,\n"
-        "3 | 01*3456789\n"
-        "  | ^\n"
+        'line 3, column 1: \n'
+        '  ,\n'
+        '3 | 01*3456789\n'
+        '  | ^\n'
         "  '");
     expect(
         _span(3, 5, map, file),
-        "line 3, column 1: \n"
-        "  ,\n"
-        "3 | 01*3456789\n"
-        "  | ^\n"
+        'line 3, column 1: \n'
+        '  ,\n'
+        '3 | 01*3456789\n'
+        '  | ^\n'
         "  '");
 
     // Start of edits map to beginning of the edit secion:
     expect(
         _span(3, 6, map, file),
-        "line 3, column 6: \n"
-        "  ,\n"
-        "3 | 01*3456789\n"
-        "  |      ^\n"
+        'line 3, column 6: \n'
+        '  ,\n'
+        '3 | 01*3456789\n'
+        '  |      ^\n'
         "  '");
     expect(
         _span(3, 7, map, file),
-        "line 3, column 6: \n"
-        "  ,\n"
-        "3 | 01*3456789\n"
-        "  |      ^\n"
+        'line 3, column 6: \n'
+        '  ,\n'
+        '3 | 01*3456789\n'
+        '  |      ^\n'
         "  '");
 
     // Lines added have no mapping (they should inherit the last mapping),
@@ -133,66 +133,66 @@ main() {
     expect(_span(4, 1, map, file), isNull);
     expect(
         _span(4, 5, map, file),
-        "line 3, column 8: \n"
-        "  ,\n"
-        "3 | 01*3456789\n"
-        "  |        ^\n"
+        'line 3, column 8: \n'
+        '  ,\n'
+        '3 | 01*3456789\n'
+        '  |        ^\n'
         "  '");
 
     // Subsequent lines are still mapped correctly:
     // a (in a___cd...)
     expect(
         _span(5, 1, map, file),
-        "line 4, column 1: \n"
-        "  ,\n"
-        "4 | abcdefghij\n"
-        "  | ^\n"
+        'line 4, column 1: \n'
+        '  ,\n'
+        '4 | abcdefghij\n'
+        '  | ^\n'
         "  '");
     // _ (in a___cd...)
     expect(
         _span(5, 2, map, file),
-        "line 4, column 2: \n"
-        "  ,\n"
-        "4 | abcdefghij\n"
-        "  |  ^\n"
+        'line 4, column 2: \n'
+        '  ,\n'
+        '4 | abcdefghij\n'
+        '  |  ^\n'
         "  '");
     // _ (in a___cd...)
     expect(
         _span(5, 3, map, file),
-        "line 4, column 2: \n"
-        "  ,\n"
-        "4 | abcdefghij\n"
-        "  |  ^\n"
+        'line 4, column 2: \n'
+        '  ,\n'
+        '4 | abcdefghij\n'
+        '  |  ^\n'
         "  '");
     // _ (in a___cd...)
     expect(
         _span(5, 4, map, file),
-        "line 4, column 2: \n"
-        "  ,\n"
-        "4 | abcdefghij\n"
-        "  |  ^\n"
+        'line 4, column 2: \n'
+        '  ,\n'
+        '4 | abcdefghij\n'
+        '  |  ^\n'
         "  '");
     // c (in a___cd...)
     expect(
         _span(5, 5, map, file),
-        "line 4, column 3: \n"
-        "  ,\n"
-        "4 | abcdefghij\n"
-        "  |   ^\n"
+        'line 4, column 3: \n'
+        '  ,\n'
+        '4 | abcdefghij\n'
+        '  |   ^\n'
         "  '");
     expect(
         _span(6, 1, map, file),
-        "line 5, column 1: \n"
-        "  ,\n"
-        "5 | abcd*fghij\n"
-        "  | ^\n"
+        'line 5, column 1: \n'
+        '  ,\n'
+        '5 | abcd*fghij\n'
+        '  | ^\n'
         "  '");
     expect(
         _span(6, 8, map, file),
-        "line 5, column 1: \n"
-        "  ,\n"
-        "5 | abcd*fghij\n"
-        "  | ^\n"
+        'line 5, column 1: \n'
+        '  ,\n'
+        '5 | abcd*fghij\n'
+        '  | ^\n'
         "  '");
   });
 }

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -8,7 +8,7 @@ library test.utils_test;
 import 'package:test/test.dart';
 import 'package:source_maps/src/utils.dart';
 
-main() {
+void main() {
   group('binary search', () {
     test('empty', () {
       expect(binarySearch([], (x) => true), -1);
@@ -30,12 +30,12 @@ main() {
     });
 
     test('compare with linear search', () {
-      for (int size = 0; size < 100; size++) {
+      for (var size = 0; size < 100; size++) {
         var list = [];
-        for (int i = 0; i < size; i++) {
+        for (var i = 0; i < size; i++) {
           list.add(i);
         }
-        for (int pos = 0; pos <= size; pos++) {
+        for (var pos = 0; pos <= size; pos++) {
           expect(binarySearch(list, (x) => x >= pos),
               _linearSearch(list, (x) => x >= pos));
         }
@@ -44,9 +44,9 @@ main() {
   });
 }
 
-_linearSearch(list, predicate) {
+int _linearSearch(list, predicate) {
   if (list.length == 0) return -1;
-  for (int i = 0; i < list.length; i++) {
+  for (var i = 0; i < list.length; i++) {
     if (predicate(list[i])) return i;
   }
   return list.length;

--- a/test/vlq_test.dart
+++ b/test/vlq_test.dart
@@ -8,7 +8,7 @@ import 'dart:math';
 import 'package:test/test.dart';
 import 'package:source_maps/src/vlq.dart';
 
-main() {
+void main() {
   test('encode and decode - simple values', () {
     expect(encodeVlq(1).join(''), 'C');
     expect(encodeVlq(2).join(''), 'E');
@@ -21,7 +21,7 @@ main() {
   });
 
   test('encode and decode', () {
-    for (int i = -10000; i < 10000; i++) {
+    for (var i = -10000; i < 10000; i++) {
       _checkEncodeDecode(i);
     }
   });
@@ -50,10 +50,10 @@ main() {
     expect(() => decodeVlq('lgggggE'.split('').iterator), throwsA(anything));
   },
       // This test uses integers so large they overflow in JS.
-      testOn: "dart-vm");
+      testOn: 'dart-vm');
 }
 
-_checkEncodeDecode(int value) {
+void _checkEncodeDecode(int value) {
   var encoded = encodeVlq(value);
   expect(decodeVlq(encoded.iterator), value);
   expect(decodeVlq(encoded.join('').split('').iterator), value);


### PR DESCRIPTION
Add an `analysis_options.yaml` which includes `package:pedantic` config.

Fix existing lints:

- always_declare_return_types
- annotate_overrides
- avoid_init_to_null
- curly_braces_in_flow_control_structures
- empty_constructor_bodies
- omit_local_variable_types
- prefer_conditional_assignment
- prefer_final_fields
- prefer_if_null_operators
- prefer_is_empty
- prefer_is_not_empty
- prefer_single_quotes
- unnecessary_this
- use_function_type_syntax_for_parameters