### PR TITLE
Handle null names field when parsing source map files

### DIFF
--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -341,7 +341,7 @@ class SingleMapping extends Mapping {
   SingleMapping.fromJson(Map map, {mapUrl})
       : targetUrl = map['file'],
         urls = List<String>.from(map['sources']),
-        names = List<String>.from(map['names']),
+        names = List<String>.from(map['names'] ?? []),
         files = List(map['sources'].length),
         sourceRoot = map['sourceRoot'],
         lines = <TargetLineEntry>[],

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -28,6 +28,14 @@ const Map<String, dynamic> MAP_WITH_SOURCE_LOCATION = {
   'file': 'output.dart'
 };
 
+const Map<String, dynamic> MAP_WITH_SOURCE_LOCATION_AND_MISSING_NAMES = {
+  'version': 3,
+  'sourceRoot': '',
+  'sources': ['input.dart'],
+  'mappings': 'AAAA',
+  'file': 'output.dart'
+};
+
 const Map<String, dynamic> MAP_WITH_SOURCE_LOCATION_AND_NAME = {
   'version': 3,
   'sourceRoot': '',
@@ -110,6 +118,20 @@ void main() {
 
   test('parse with source location and no name', () {
     SingleMapping map = parse(jsonEncode(MAP_WITH_SOURCE_LOCATION));
+    expect(map.lines.length, 1);
+    expect(map.lines.first.entries.length, 1);
+    var entry = map.lines.first.entries.first;
+
+    expect(entry.column, 0);
+    expect(entry.sourceUrlId, 0);
+    expect(entry.sourceColumn, 0);
+    expect(entry.sourceLine, 0);
+    expect(entry.sourceNameId, null);
+  });
+
+  test('parse with source location and missing names entry', () {
+    SingleMapping map =
+        parse(jsonEncode(MAP_WITH_SOURCE_LOCATION_AND_MISSING_NAMES));
     expect(map.lines.length, 1);
     expect(map.lines.first.entries.length, 1);
     var entry = map.lines.first.entries.first;


### PR DESCRIPTION
### Problem:
If `names` doesn't exist in a source map file, parsing it fails with the following exception:

```
  NoSuchMethodError: The getter 'iterator' was called on null.
  Receiver: null
  Tried calling: iterator
  dart:core                               new List.from
  package:source_maps/parser.dart 345:15  new SingleMapping.fromJson
  package:source_maps/parser.dart 72:24   parseJson
  package:source_maps/parser.dart 27:5    parse
  test/parser_test.dart 134:9             main.<fn>
```

Source maps created by Dart tooling don't seem to omit this field. However, you will encounter this exception if you use this library to parse a source map that was created by tooling that omits the `names` field when the list is empty. For example, the Go package used by gopherjs to generate source maps [omits fields when they are empty](https://github.com/neelance/sourcemap/blob/master/sourcemap.go#L16). We could update that package so it doesn't omit empty fields when encoding them to json, but it's certainly possible this could be an issue with source maps generated by other toolchains as well.

### Solution:
Added a null-aware operator to treat a missing `names` field as an empty list.