### PR TITLE
allow the 2.12 prerelease sdks and prep to release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.10-nullsafety.2
+
+* Allow prerelease versions of the 2.12 sdk.
+
 ## 0.10.10-nullsafety.1
 
 * Allow 2.10 stable and 2.11.0 dev SDK versions.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,74 +1,16 @@
 name: source_maps
-version: 0.10.10-nullsafety.1
+version: 0.10.10-nullsafety.2
 
 description: Library to programmatically manipulate source map files.
 homepage: https://github.com/dart-lang/source_maps
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.11.0'
+  sdk: '>=2.10.0-0 <2.12.0'
 
 dependencies:
   source_span: '>=1.8.0-nullsafety <1.8.0'
 
 dev_dependencies:
-  test: ^1.2.0
-  term_glyph: ^1.0.0
-
-dependency_overrides:
-  # Overrides required for a version solve	
-  coverage: 0.14.0
-  # Null Safety Overrides
-  async:
-    git: git://github.com/dart-lang/async.git
-  boolean_selector:
-    git: git://github.com/dart-lang/boolean_selector.git
-  charcode:
-    git: git://github.com/dart-lang/charcode.git
-  collection:
-    git: git://github.com/dart-lang/collection.git
-  js:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/js
-      ref: 2-10-pkgs
-  matcher:
-    git: git://github.com/dart-lang/matcher.git
-  meta:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/meta
-      ref: 2-10-pkgs
-  path:
-    git: git://github.com/dart-lang/path.git
-  pedantic:
-    git: git://github.com/dart-lang/pedantic.git
-  pool:
-    git: git://github.com/dart-lang/pool.git
-  source_map_stack_trace:
-    git: git://github.com/dart-lang/source_map_stack_trace.git
-  source_span:
-    git: git://github.com/dart-lang/source_span.git
-  stack_trace:
-    git: git://github.com/dart-lang/stack_trace.git
-  stream_channel:
-    git: git://github.com/dart-lang/stream_channel.git
-  string_scanner:
-    git: git://github.com/dart-lang/string_scanner.git
-  term_glyph:
-    git: git://github.com/dart-lang/term_glyph.git
-  test_api:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test_api
-  test_core:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test_core
-  test:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test
-  typed_data:
-    git: git://github.com/dart-lang/typed_data.git
-
+  test: ^1.16.0-nullsafety
+  term_glyph: ^1.2.0-nullsafety


### PR DESCRIPTION
- also remove git overrides in favor of real deps