### PR TITLE
tighten up analysis; add types at the api boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.12
+
+* Add additional types at API boundaries.
+
 # 0.10.11
 
 * Populate the pubspec `repository` field.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 [![pub package](https://img.shields.io/pub/v/source_maps.svg)](https://pub.dev/packages/source_maps)
 [![package publisher](https://img.shields.io/pub/publisher/source_maps.svg)](https://pub.dev/packages/source_maps/publisher)
 
-This project implements a Dart pub package to work with source maps. The
-implementation is based on the [source map version 3 spec][spec] which was
+This project implements a Dart pub package to work with source maps.
+
+## Docs and usage
+
+The implementation is based on the [source map version 3 spec][spec] which was
 originated from the [Closure Compiler][closure] and has been implemented in
 Chrome and Firefox.
 
@@ -17,14 +20,6 @@ In this package we provide:
     source map format.
   * A parser that reads the source map format and provides APIs to read the
     mapping information.
-
-Some upcoming features we are planning to add to this package are:
-
-  * A printer that lets you generate code, but record source map information in
-    the process.
-  * A tool that can compose source maps together. This would be useful for
-    instance, if you have 2 tools that produce source maps and you call one with
-    the result of the other.
 
 [closure]: https://github.com/google/closure-compiler/wiki/Source-Maps
 [spec]: https://docs.google.com/a/google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,1 @@
-include: package:lints/recommended.yaml
-
-linter:
-  rules:
-    - comment_references
+include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -45,7 +45,7 @@ class SourceMapBuilder {
   }
 
   /// Encodes all mappings added to this builder as a json map.
-  Map build(String fileUrl) {
+  Map<String, dynamic> build(String fileUrl) {
     return SingleMapping.fromEntries(_entries, fileUrl).toJson();
   }
 

--- a/lib/printer.dart
+++ b/lib/printer.dart
@@ -36,7 +36,7 @@ class Printer {
   /// adds a source map location on each new line, projecting that every new
   /// line in the target file (printed here) corresponds to a new line in the
   /// source file.
-  void add(String str, {projectMarks = false}) {
+  void add(String str, {bool projectMarks = false}) {
     var chars = str.runes.toList();
     var length = chars.length;
     for (var i = 0; i < length; i++) {
@@ -85,7 +85,7 @@ class Printer {
   /// [SourceSpan]. When the mark is a [SourceMapSpan] with `isIdentifier` set,
   /// this also records the name of the identifier in the source map
   /// information.
-  void mark(mark) {
+  void mark(Object mark) {
     late final SourceLocation loc;
     String? identifier;
     if (mark is SourceLocation) {
@@ -105,13 +105,13 @@ class Printer {
 /// including [NestedPrinter]s, and it let's you automatically indent text.
 ///
 /// This class is especially useful when doing code generation, where different
-/// peices of the code are generated independently on separate printers, and are
+/// pieces of the code are generated independently on separate printers, and are
 /// finally put together in the end.
 class NestedPrinter implements NestedItem {
   /// Items recoded by this printer, which can be [String] literals,
   /// [NestedItem]s, and source map information like [SourceLocation] and
   /// [SourceSpan].
-  final _items = <dynamic>[];
+  final List<Object> _items = [];
 
   /// Internal buffer to merge consecutive strings added to this printer.
   StringBuffer? _buff;
@@ -149,7 +149,7 @@ class NestedPrinter implements NestedItem {
   /// Indicate [isOriginal] when [object] is copied directly from the user code.
   /// Setting [isOriginal] will make this printer propagate source map locations
   /// on every line-break.
-  void add(object,
+  void add(Object object,
       {SourceLocation? location, SourceSpan? span, bool isOriginal = false}) {
     if (object is! String || location != null || span != null || isOriginal) {
       _flush();

--- a/lib/refactor.dart
+++ b/lib/refactor.dart
@@ -30,7 +30,7 @@ class TextEditTransaction {
   /// Edit the original text, replacing text on the range [begin] and [end]
   /// with the [replacement]. [replacement] can be either a string or a
   /// [NestedPrinter].
-  void edit(int begin, int end, replacement) {
+  void edit(int begin, int end, Object replacement) {
     _edits.add(_TextEdit(begin, end, replacement));
   }
 

--- a/lib/source_maps.dart
+++ b/lib/source_maps.dart
@@ -28,8 +28,8 @@ library source_maps;
 
 import 'package:source_span/source_span.dart';
 
-import 'parser.dart';
 import 'builder.dart';
+import 'parser.dart';
 
 export 'builder.dart';
 export 'parser.dart';

--- a/lib/src/source_map_span.dart
+++ b/lib/src/source_map_span.dart
@@ -61,13 +61,13 @@ class SourceMapFileSpan implements SourceMapSpan, FileSpan {
   @override
   int compareTo(SourceSpan other) => _inner.compareTo(other);
   @override
-  String highlight({color}) => _inner.highlight(color: color);
+  String highlight({Object? color}) => _inner.highlight(color: color);
   @override
   SourceSpan union(SourceSpan other) => _inner.union(other);
   @override
   FileSpan expand(FileSpan other) => _inner.expand(other);
   @override
-  String message(String message, {color}) =>
+  String message(String message, {Object? color}) =>
       _inner.message(message, color: color);
   @override
   String toString() =>

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -10,7 +10,7 @@ library source_maps.utils;
 /// and all items after `n` match too. The result is -1 when there are no
 /// items, 0 when all items match, and list.length when none does.
 // TODO(sigmund): remove this function after dartbug.com/5624 is fixed.
-int binarySearch(List list, bool Function(dynamic) matches) {
+int binarySearch<T>(List<T> list, bool Function(T) matches) {
   if (list.isEmpty) return -1;
   if (matches(list.first)) return 0;
   if (!matches(list.last)) return list.length;

--- a/lib/src/vlq.dart
+++ b/lib/src/vlq.dart
@@ -76,7 +76,7 @@ int decodeVlq(Iterator<String> chars) {
     }
     stop = (digit & vlqContinuationBit) == 0;
     digit &= vlqBaseMask;
-    result += (digit << shift);
+    result += digit << shift;
     shift += vlqBaseShift;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_maps
-version: 0.10.11
+version: 0.10.12
 description: A library to programmatically manipulate source map files.
 repository: https://github.com/dart-lang/source_maps
 
@@ -10,6 +10,6 @@ dependencies:
   source_span: ^1.8.0
 
 dev_dependencies:
-  lints: ^2.0.0
+  dart_flutter_team_lints: ^0.1.0
   term_glyph: ^1.2.0
   test: ^1.16.0

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -373,7 +373,7 @@ void main() {
     var mapping = parseJson(map) as SingleMapping;
     expect(mapping.toJson(), equals(map));
     expect(mapping.extensions['x_foo'], equals('a'));
-    expect(mapping.extensions['x_bar'].first, equals(3));
+    expect((mapping.extensions['x_bar'] as List).first, equals(3));
   });
 
   group('source files', () {

--- a/test/refactor_test.dart
+++ b/test/refactor_test.dart
@@ -4,11 +4,11 @@
 
 library polymer.test.refactor_test;
 
-import 'package:test/test.dart';
-import 'package:source_maps/refactor.dart';
 import 'package:source_maps/parser.dart' show parse, Mapping;
+import 'package:source_maps/refactor.dart';
 import 'package:source_span/source_span.dart';
 import 'package:term_glyph/term_glyph.dart' as term_glyph;
+import 'package:test/test.dart';
 
 void main() {
   setUpAll(() {

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -5,8 +5,8 @@
 /// Tests for the binary search utility algorithm.
 library test.utils_test;
 
-import 'package:test/test.dart';
 import 'package:source_maps/src/utils.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('binary search', () {
@@ -31,7 +31,7 @@ void main() {
 
     test('compare with linear search', () {
       for (var size = 0; size < 100; size++) {
-        var list = [];
+        var list = <int>[];
         for (var i = 0; i < size; i++) {
           list.add(i);
         }
@@ -44,8 +44,8 @@ void main() {
   });
 }
 
-int _linearSearch(list, predicate) {
-  if (list.length == 0) return -1;
+int _linearSearch<T>(List<T> list, bool Function(T) predicate) {
+  if (list.isEmpty) return -1;
   for (var i = 0; i < list.length; i++) {
     if (predicate(list[i])) return i;
   }

--- a/test/vlq_test.dart
+++ b/test/vlq_test.dart
@@ -5,8 +5,9 @@
 library test.vlq_test;
 
 import 'dart:math';
-import 'package:test/test.dart';
+
 import 'package:source_maps/src/vlq.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('encode and decode - simple values', () {


### PR DESCRIPTION
- switch to using `package:dart_flutter_team_lints`
- based on the above lints, add more types at the API boundaries (method params and return types)

I've rev'd the package version from `0.10.11` to `0.10.12`, but perhaps expecting more specific types in the method params is technically a breaking change (expecting a `Map<String, dynamic>` instead of just a `Map`).
